### PR TITLE
Update test to remove call to `input()`

### DIFF
--- a/client/src/app/users/user-card.component.spec.ts
+++ b/client/src/app/users/user-card.component.spec.ts
@@ -1,12 +1,13 @@
-import { input } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { MatCardModule } from '@angular/material/card';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { UserCardComponent } from './user-card.component';
+import { User } from './user';
 
 describe('UserCardComponent', () => {
   let component: UserCardComponent;
   let fixture: ComponentFixture<UserCardComponent>;
+  let expectedUser: User;
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
@@ -19,24 +20,28 @@ describe('UserCardComponent', () => {
       .compileComponents();
   }));
 
-  beforeEach(() => {
+  beforeEach(async () => {
     fixture = TestBed.createComponent(UserCardComponent);
     component = fixture.componentInstance;
-    TestBed.runInInjectionContext(() => {
-      component.user = input({
-        _id: 'chris_id',
-        name: 'Chris',
-        age: 25,
-        company: 'UMM',
-        email: 'chris@this.that',
-        role: 'admin',
-        avatar: 'https://gravatar.com/avatar/8c9616d6cc5de638ea6920fb5d65fc6c?d=identicon'
-      })
-    });
-    fixture.detectChanges();
+    expectedUser = {
+      _id: 'chris_id',
+      name: 'Chris',
+      age: 25,
+      company: 'UMM',
+      email: 'chris@this.that',
+      role: 'admin',
+      avatar: 'https://gravatar.com/avatar/8c9616d6cc5de638ea6920fb5d65fc6c?d=identicon'
+    };
+    fixture.componentRef.setInput('user', expectedUser);
+
+    await fixture.whenStable();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  it('should be associated with the appropriate user', () => {
+    expect(component.user()).toEqual(expectedUser);
+  })
 });


### PR DESCRIPTION
This test contained an unsupported call to the `input` function (according to an error (maybe from eslint, but not sure about that)). I think this is a result of the switch to signals, but maybe not. Here is a link to what I used as a guide: https://angular.dev/guide/testing/components-scenarios#test-dashboardherocomponent-standalone