### PR TITLE
Add some formatting rules to eslint and set them to auto apply on save

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,6 +7,9 @@
       "typescript",
       "html"
     ],
+    "editor.codeActionsOnSave": {
+      "source.fixAll.eslint": "explicit"
+    },
     "cSpell.words": [
       "anisabboud",
       "apdisk",

--- a/client/cypress/e2e/user-list.cy.ts
+++ b/client/cypress/e2e/user-list.cy.ts
@@ -127,7 +127,7 @@ describe('User list', () => {
       cy.get('.user-card-name').first().should('have.text', firstUserName);
       cy.get('.user-card-company').first().should('have.text', firstUserCompany);
     });
-   });
+  });
 
   it('Should click add user and go to the right URL', () => {
     // Click on the button for adding a new user

--- a/client/cypress/support/company-list.po.ts
+++ b/client/cypress/support/company-list.po.ts
@@ -28,7 +28,7 @@ export class CompanyListPage {
    * @returns an iterable (`Cypress.Chainable`) containing all
    *   the `company-card` DOM elements.
    */
-   getCompanyCards() {
+  getCompanyCards() {
     return cy.get(this.companyCardSelector);
   }
 
@@ -44,20 +44,20 @@ export class CompanyListPage {
       .contains(companyName)
       // Return the containing company card element
       .parents('.company-card');
-    }
-
-    /**
-     * Get the list of users for a given `company-card` DOM element
-     * by its name (which is in the `_id`) field.
-     */
-    getCompanyCardUserNames(companyName: string) {
-      // Get the company card by name, then find the user names
-      return this
-         // Get the `.company-card` element for the given
-         // company name
-        .getCompanyCardByName(companyName)
-        // Find all the `.company-card-user-name` elements
-        // within the company card
-        .find('.company-card-user-name');
-    }
   }
+
+  /**
+   * Get the list of users for a given `company-card` DOM element
+   * by its name (which is in the `_id`) field.
+   */
+  getCompanyCardUserNames(companyName: string) {
+    // Get the company card by name, then find the user names
+    return this
+    // Get the `.company-card` element for the given
+    // company name
+      .getCompanyCardByName(companyName)
+    // Find all the `.company-card-user-name` elements
+    // within the company card
+      .find('.company-card-user-name');
+  }
+}

--- a/client/cypress/support/user-list.po.ts
+++ b/client/cypress/support/user-list.po.ts
@@ -31,7 +31,7 @@ export class UserListPage {
    * @returns an iterable (`Cypress.Chainable`) containing all
    *   the `app-user-card` DOM elements.
    */
-   getUserCards() {
+  getUserCards() {
     return cy.get(this.userCardSelector);
   }
 

--- a/client/eslint.config.mjs
+++ b/client/eslint.config.mjs
@@ -2,6 +2,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import js from "@eslint/js";
 import { FlatCompat } from "@eslint/eslintrc";
+// https://eslint.org/docs/latest/rules/
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -40,6 +41,17 @@ export default [{
         "no-underscore-dangle": ["error", {
             allow: ["_id"],
         }],
+
+        // The following few rules are more about how the code looks than how it functions,
+        // but these are places where consistency stands out and can be confusing.
+        // angular-eslint is more focused on functionality, so this is not promised to work forever:
+        // https://github.com/angular-eslint/angular-eslint/blob/main/docs/FORMATTING_RULES.md
+        "indent": ["error", 2],         // https://archive.eslint.org/docs/rules/indent
+        "space-before-blocks": "error", // https://archive.eslint.org/docs/rules/space-before-blocks
+        "no-trailing-spaces": "error",  // https://archive.eslint.org/docs/rules/no-trailing-spaces
+        "brace-style": "error",         // https://archive.eslint.org/docs/rules/brace-style
+        "func-call-spacing": "error",   // https://archive.eslint.org/docs/rules/func-call-spacing
+        "arrow-spacing": "error",       // https://archive.eslint.org/docs/rules/arrow-spacing
     },
 }, ...compat.extends(
     "plugin:@angular-eslint/template/recommended",

--- a/client/src/app/app.component.spec.ts
+++ b/client/src/app/app.component.spec.ts
@@ -11,7 +11,7 @@ import { AppComponent } from './app.component';
 describe('AppComponent', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-    imports: [
+      imports: [
         BrowserAnimationsModule,
         RouterModule.forRoot([]),
         MatToolbarModule,
@@ -20,8 +20,8 @@ describe('AppComponent', () => {
         MatCardModule,
         MatListModule,
         AppComponent
-    ],
-}).compileComponents();
+      ],
+    }).compileComponents();
   }));
 
   it('should create the app', () => {

--- a/client/src/app/app.component.ts
+++ b/client/src/app/app.component.ts
@@ -7,10 +7,10 @@ import { MatToolbarModule } from '@angular/material/toolbar';
 import { RouterLink, RouterLinkActive, RouterOutlet } from '@angular/router';
 
 @Component({
-    selector: 'app-root',
-    templateUrl: './app.component.html',
-    styleUrls: ['./app.component.scss'],
-    imports: [MatSidenavModule, MatToolbarModule, MatListModule, RouterLink, RouterLinkActive, MatIconModule, MatButtonModule, RouterOutlet]
+  selector: 'app-root',
+  templateUrl: './app.component.html',
+  styleUrls: ['./app.component.scss'],
+  imports: [MatSidenavModule, MatToolbarModule, MatListModule, RouterLink, RouterLinkActive, MatIconModule, MatButtonModule, RouterOutlet]
 })
 export class AppComponent {
   title = 'CSCI 3601 Iteration Template';

--- a/client/src/app/company-card/company-card.component.spec.ts
+++ b/client/src/app/company-card/company-card.component.spec.ts
@@ -10,7 +10,7 @@ describe('CompanyCardComponent', () => {
     await TestBed.configureTestingModule({
       imports: [CompanyCardComponent]
     })
-    .compileComponents();
+      .compileComponents();
 
     fixture = TestBed.createComponent(CompanyCardComponent);
     component = fixture.componentInstance;

--- a/client/src/app/company-list/company-list.component.spec.ts
+++ b/client/src/app/company-list/company-list.component.spec.ts
@@ -34,7 +34,7 @@ describe('CompanyListComponent', () => {
       imports: [CompanyListComponent],
       providers: [ { provide: UserService, useValue: userServiceStub } ]
     })
-    .compileComponents();
+      .compileComponents();
 
     fixture = TestBed.createComponent(CompanyListComponent);
     component = fixture.componentInstance;

--- a/client/src/app/home/home.component.spec.ts
+++ b/client/src/app/home/home.component.spec.ts
@@ -13,8 +13,8 @@ describe('Home', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-    imports: [MatCardModule, HomeComponent],
-});
+      imports: [MatCardModule, HomeComponent],
+    });
 
     fixture = TestBed.createComponent(HomeComponent);
 

--- a/client/src/app/home/home.component.ts
+++ b/client/src/app/home/home.component.ts
@@ -2,11 +2,11 @@ import { Component } from '@angular/core';
 import { MatCardModule } from '@angular/material/card';
 
 @Component({
-    selector: 'app-home-component',
-    templateUrl: 'home.component.html',
-    styleUrls: ['./home.component.scss'],
-    providers: [],
-    imports: [MatCardModule]
+  selector: 'app-home-component',
+  templateUrl: 'home.component.html',
+  styleUrls: ['./home.component.scss'],
+  providers: [],
+  imports: [MatCardModule]
 })
 export class HomeComponent {
 

--- a/client/src/app/users/add-user.component.spec.ts
+++ b/client/src/app/users/add-user.component.spec.ts
@@ -24,7 +24,7 @@ describe('AddUserComponent', () => {
   beforeEach(waitForAsync(() => {
     TestBed.overrideProvider(UserService, { useValue: new MockUserService() });
     TestBed.configureTestingModule({
-    imports: [
+      imports: [
         FormsModule,
         ReactiveFormsModule,
         MatSnackBarModule,
@@ -35,8 +35,8 @@ describe('AddUserComponent', () => {
         BrowserAnimationsModule,
         RouterModule,
         AddUserComponent
-    ],
-}).compileComponents().catch(error => {
+      ],
+    }).compileComponents().catch(error => {
       expect(error).toBeNull();
     });
   }));
@@ -275,18 +275,18 @@ describe('AddUserComponent#submitForm()', () => {
   beforeEach(() => {
     TestBed.overrideProvider(UserService, { useValue: new MockUserService() });
     TestBed.configureTestingModule({
-    imports: [ReactiveFormsModule,
+      imports: [ReactiveFormsModule,
         MatSnackBarModule,
         MatCardModule,
         MatSelectModule,
         MatInputModule,
         BrowserAnimationsModule,
         RouterModule.forRoot([
-            { path: 'users/1', component: UserProfileComponent }
+          { path: 'users/1', component: UserProfileComponent }
         ]),
         AddUserComponent, UserProfileComponent],
-    providers: [provideHttpClient(withInterceptorsFromDi()), provideHttpClientTesting()]
-}).compileComponents().catch(error => {
+      providers: [provideHttpClient(withInterceptorsFromDi()), provideHttpClientTesting()]
+    }).compileComponents().catch(error => {
       expect(error).toBeNull();
     });
   });

--- a/client/src/app/users/add-user.component.ts
+++ b/client/src/app/users/add-user.component.ts
@@ -12,10 +12,10 @@ import { UserRole } from './user';
 import { UserService } from './user.service';
 
 @Component({
-    selector: 'app-add-user',
-    templateUrl: './add-user.component.html',
-    styleUrls: ['./add-user.component.scss'],
-    imports: [FormsModule, ReactiveFormsModule, MatCardModule, MatFormFieldModule, MatInputModule, MatSelectModule, MatOptionModule, MatButtonModule]
+  selector: 'app-add-user',
+  templateUrl: './add-user.component.html',
+  styleUrls: ['./add-user.component.scss'],
+  imports: [FormsModule, ReactiveFormsModule, MatCardModule, MatFormFieldModule, MatInputModule, MatSelectModule, MatOptionModule, MatButtonModule]
 })
 export class AddUserComponent {
 

--- a/client/src/app/users/user-card.component.ts
+++ b/client/src/app/users/user-card.component.ts
@@ -7,10 +7,10 @@ import { RouterLink } from '@angular/router';
 import { User } from './user';
 
 @Component({
-    selector: 'app-user-card',
-    templateUrl: './user-card.component.html',
-    styleUrls: ['./user-card.component.scss'],
-    imports: [MatCardModule, MatButtonModule, MatListModule, MatIconModule, RouterLink]
+  selector: 'app-user-card',
+  templateUrl: './user-card.component.html',
+  styleUrls: ['./user-card.component.scss'],
+  imports: [MatCardModule, MatButtonModule, MatListModule, MatIconModule, RouterLink]
 })
 export class UserCardComponent {
 

--- a/client/src/app/users/user.service.spec.ts
+++ b/client/src/app/users/user.service.spec.ts
@@ -46,9 +46,9 @@ describe('UserService', () => {
   beforeEach(() => {
     // Set up the mock handling of the HTTP requests
     TestBed.configureTestingModule({
-    imports: [],
-    providers: [provideHttpClient(withInterceptorsFromDi()), provideHttpClientTesting()]
-});
+      imports: [],
+      providers: [provideHttpClient(withInterceptorsFromDi()), provideHttpClientTesting()]
+    });
     // Construct an instance of the service with the mock
     // HTTP client.
     httpClient = TestBed.inject(HttpClient);
@@ -62,7 +62,7 @@ describe('UserService', () => {
   });
 
   describe('When getUsers() is called with no parameters', () => {
-   /* We really don't care what `getUsers()` returns. Since all the
+    /* We really don't care what `getUsers()` returns. Since all the
     * filtering (when there is any) is happening on the server,
     * `getUsers()` is really just a "pass through" that returns whatever it receives,
     * without any "post processing" or manipulation. The test in this
@@ -128,20 +128,20 @@ describe('UserService', () => {
     */
 
     it('correctly calls api/users with filter parameter \'admin\'', () => {
-        const mockedMethod = spyOn(httpClient, 'get').and.returnValue(of(testUsers));
+      const mockedMethod = spyOn(httpClient, 'get').and.returnValue(of(testUsers));
 
-        userService.getUsers({ role: 'admin' }).subscribe(() => {
-          expect(mockedMethod)
-            .withContext('one call')
-            .toHaveBeenCalledTimes(1);
-          // The mocked method should have been called with two arguments:
-          //   * the appropriate URL ('/api/users' defined in the `UserService`)
-          //   * An options object containing an `HttpParams` with the `role`:`admin`
-          //     key-value pair.
-          expect(mockedMethod)
-            .withContext('talks to the correct endpoint')
-            .toHaveBeenCalledWith(userService.userUrl, { params: new HttpParams().set('role', 'admin') });
-        });
+      userService.getUsers({ role: 'admin' }).subscribe(() => {
+        expect(mockedMethod)
+          .withContext('one call')
+          .toHaveBeenCalledTimes(1);
+        // The mocked method should have been called with two arguments:
+        //   * the appropriate URL ('/api/users' defined in the `UserService`)
+        //   * An options object containing an `HttpParams` with the `role`:`admin`
+        //     key-value pair.
+        expect(mockedMethod)
+          .withContext('talks to the correct endpoint')
+          .toHaveBeenCalledWith(userService.userUrl, { params: new HttpParams().set('role', 'admin') });
+      });
     });
 
     it('correctly calls api/users with filter parameter \'age\'', () => {
@@ -158,49 +158,49 @@ describe('UserService', () => {
     });
 
     it('correctly calls api/users with multiple filter parameters', () => {
-        const mockedMethod = spyOn(httpClient, 'get').and.returnValue(of(testUsers));
+      const mockedMethod = spyOn(httpClient, 'get').and.returnValue(of(testUsers));
 
-        userService.getUsers({ role: 'editor', company: 'IBM', age: 37 }).subscribe(() => {
-          // This test checks that the call to `userService.getUsers()` does several things:
-          //   * It calls the mocked method (`HttpClient#get()`) exactly once.
-          //   * It calls it with the correct endpoint (`userService.userUrl`).
-          //   * It calls it with the correct parameters:
-          //      * There should be three parameters (this makes sure that there aren't extras).
-          //      * There should be a "role:editor" key-value pair.
-          //      * And a "company:IBM" pair.
-          //      * And a "age:37" pair.
+      userService.getUsers({ role: 'editor', company: 'IBM', age: 37 }).subscribe(() => {
+        // This test checks that the call to `userService.getUsers()` does several things:
+        //   * It calls the mocked method (`HttpClient#get()`) exactly once.
+        //   * It calls it with the correct endpoint (`userService.userUrl`).
+        //   * It calls it with the correct parameters:
+        //      * There should be three parameters (this makes sure that there aren't extras).
+        //      * There should be a "role:editor" key-value pair.
+        //      * And a "company:IBM" pair.
+        //      * And a "age:37" pair.
 
-          // This gets the arguments for the first (and in this case only) call to the `mockMethod`.
-          const [url, options] = mockedMethod.calls.argsFor(0);
-          // Gets the `HttpParams` from the options part of the call.
-          // `options.param` can return any of a broad number of types;
-          // it is in fact an instance of `HttpParams`, and I need to use
-          // that fact, so I'm casting it (the `as HttpParams` bit).
-          const calledHttpParams: HttpParams = (options.params) as HttpParams;
-          expect(mockedMethod)
-            .withContext('one call')
-            .toHaveBeenCalledTimes(1);
-          expect(url)
-            .withContext('talks to the correct endpoint')
-            .toEqual(userService.userUrl);
-          expect(calledHttpParams.keys().length)
-            .withContext('should have 3 params')
-            .toEqual(3);
-          expect(calledHttpParams.get('role'))
-            .withContext('role of editor')
-            .toEqual('editor');
-          expect(calledHttpParams.get('company'))
-            .withContext('company being IBM')
-            .toEqual('IBM');
-          expect(calledHttpParams.get('age'))
-            .withContext('age being 37')
-            .toEqual('37');
-        });
+        // This gets the arguments for the first (and in this case only) call to the `mockMethod`.
+        const [url, options] = mockedMethod.calls.argsFor(0);
+        // Gets the `HttpParams` from the options part of the call.
+        // `options.param` can return any of a broad number of types;
+        // it is in fact an instance of `HttpParams`, and I need to use
+        // that fact, so I'm casting it (the `as HttpParams` bit).
+        const calledHttpParams: HttpParams = (options.params) as HttpParams;
+        expect(mockedMethod)
+          .withContext('one call')
+          .toHaveBeenCalledTimes(1);
+        expect(url)
+          .withContext('talks to the correct endpoint')
+          .toEqual(userService.userUrl);
+        expect(calledHttpParams.keys().length)
+          .withContext('should have 3 params')
+          .toEqual(3);
+        expect(calledHttpParams.get('role'))
+          .withContext('role of editor')
+          .toEqual('editor');
+        expect(calledHttpParams.get('company'))
+          .withContext('company being IBM')
+          .toEqual('IBM');
+        expect(calledHttpParams.get('age'))
+          .withContext('age being 37')
+          .toEqual('37');
+      });
     });
   });
 
   describe('When getUserById() is given an ID', () => {
-   /* We really don't care what `getUserById()` returns. Since all the
+    /* We really don't care what `getUserById()` returns. Since all the
     * interesting work is happening on the server, `getUserById()`
     * is really just a "pass through" that returns whatever it receives,
     * without any "post processing" or manipulation. The test in this

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -48,10 +48,10 @@ if (environment.production) {
 }
 
 bootstrapApplication(AppComponent, {
-    providers: [
-        importProvidersFrom(BrowserModule, AppRoutingModule, FormsModule, ReactiveFormsModule, MATERIAL_MODULES, LayoutModule),
-        provideAnimations(),
-        provideHttpClient(withInterceptorsFromDi())
-    ]
+  providers: [
+    importProvidersFrom(BrowserModule, AppRoutingModule, FormsModule, ReactiveFormsModule, MATERIAL_MODULES, LayoutModule),
+    provideAnimations(),
+    provideHttpClient(withInterceptorsFromDi())
+  ]
 })
   .catch(err => console.error(err));


### PR DESCRIPTION
This PR will have failing checks until the PR with the changes made in response to these rule changes is merged. Then, it should pass.

#15 

I added some rules where I would be able to see the corrections and feel more confident that eslint was working. It's not generally the goal of eslint to fix formatting and focus on what the code looks like. I'm going to keep the changes to the rules on a separate PR, but I did make these changes based on the rules. It does make things more consistent, even if it's mostly cosmetic.

        // The following few rules are more about how the code looks than how it functions,
        // but these are places where consistency stands out and can be confusing.
        // angular-eslint is more focused on functionality, so this is not promised to work forever:
        // https://github.com/angular-eslint/angular-eslint/blob/main/docs/FORMATTING_RULES.md
        "indent": ["error", 2],         // https://archive.eslint.org/docs/rules/indent
        "space-before-blocks": "error", // https://archive.eslint.org/docs/rules/space-before-blocks
        "no-trailing-spaces": "error",  // https://archive.eslint.org/docs/rules/no-trailing-spaces
        "brace-style": "error",         // https://archive.eslint.org/docs/rules/brace-style
        "func-call-spacing": "error",   // https://archive.eslint.org/docs/rules/func-call-spacing
        "arrow-spacing": "error",       // https://archive.eslint.org/docs/rules/arrow-spacing