### PR TITLE
Remove unsupported call to input in user-card test

### DIFF
--- a/client/src/app/users/user-card.component.spec.ts
+++ b/client/src/app/users/user-card.component.spec.ts
@@ -1,12 +1,13 @@
-import { input } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { MatCardModule } from '@angular/material/card';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { UserCardComponent } from './user-card.component';
+import { User } from './user';
 
 describe('UserCardComponent', () => {
   let component: UserCardComponent;
   let fixture: ComponentFixture<UserCardComponent>;
+  let expectedUser: User;
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
@@ -23,7 +24,7 @@ describe('UserCardComponent', () => {
     fixture = TestBed.createComponent(UserCardComponent);
     component = fixture.componentInstance;
     TestBed.runInInjectionContext(() => {
-      component.user = input({
+      expectedUser = {
         _id: 'chris_id',
         name: 'Chris',
         age: 25,
@@ -31,12 +32,21 @@ describe('UserCardComponent', () => {
         email: 'chris@this.that',
         role: 'admin',
         avatar: 'https://gravatar.com/avatar/8c9616d6cc5de638ea6920fb5d65fc6c?d=identicon'
-      })
+      };
     });
+    fixture.componentRef.setInput('user', expectedUser);
     fixture.detectChanges();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should be associated with the correct user', () => {
+    expect(component.user()).toEqual(expectedUser);
+  });
+
+  it('should be the user named Chris', () => {
+    expect(component.user().name).toEqual('Chris');
   });
 });


### PR DESCRIPTION
After a couple of attempts to update this test, I think this is the way I'm going to stick with. The use of `TestBed.runInInjectionContext` involves less change to the test than the other approaches.

This code included an unsupported call to the `input` function. This commit follows a bit more of the Angular 19 approach (for testing signals). I also tried another approach more like this:

```
beforeEach(async () => {
    fixture = TestBed.createComponent(UserCardComponent);
    component = fixture.componentInstance;
    expectedUser = {
      _id: 'chris_id',
      name: 'Chris',
      age: 25,
      company: 'UMM',
      email: 'chris@this.that',
      role: 'admin',
      avatar: 'https://gravatar.com/avatar/8c9616d6cc5de638ea6920fb5d65fc6c?d=identicon'
    };
    fixture.componentRef.setInput('user', expectedUser);
    await fixture.whenStable();
  });
```

See documentation for the example that most helped me with this:
https://angular.dev/guide/testing/components-scenarios#test-dashboardherocomponent-standalone

I'm not sure which one follows the more Angular approach, to be honest.