### PR TITLE
Move statement about disabling warnings back

### DIFF
--- a/client/src/testing/user.service.mock.ts
+++ b/client/src/testing/user.service.mock.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
 import { Injectable } from '@angular/core';
 import { Observable, of } from 'rxjs';
 import { AppComponent } from 'src/app/app.component';
@@ -47,7 +46,7 @@ export class MockUserService implements Pick<UserService, 'getUsers' | 'getUserB
   // skipcq: JS-0105
   // It's OK that the `_filters` argument isn't used here, so we'll disable
   // this warning for just his function.
-
+  /* eslint-disable @typescript-eslint/no-unused-vars */
   getUsers(_filters: { role?: UserRole; age?: number; company?: string }): Observable<User[]> {
     // Our goal here isn't to test (and thus rewrite) the service, so we'll
     // keep it simple and just return the test users regardless of what


### PR DESCRIPTION
Specifically disabling warnings exactly where they are needed is preferred. Copilot initially pointed out this suggestion.
