### PR TITLE
Add injection of MatSnackBar

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -65,6 +65,7 @@
       "Lamberty",
       "lastdir",
       "libpeerconnection",
+      "maxlength",
       "metacharacter",
       "MOMENTIA",
       "mongoimport",

--- a/client/src/app/users/add-user.component.spec.ts
+++ b/client/src/app/users/add-user.component.spec.ts
@@ -3,6 +3,7 @@ import { HttpTestingController, provideHttpClientTesting } from '@angular/common
 import { ComponentFixture, TestBed, fakeAsync, flush, tick, waitForAsync } from '@angular/core/testing';
 import { AbstractControl, FormGroup } from '@angular/forms';
 import { provideRouter, Router } from '@angular/router';
+import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { of, throwError } from 'rxjs';
 import { MockUserService } from 'src/testing/user.service.mock';
 import { AddUserComponent } from './add-user.component';
@@ -18,7 +19,8 @@ describe('AddUserComponent', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [
-        AddUserComponent
+        AddUserComponent,
+        MatSnackBarModule
       ],
       providers: [
         provideHttpClient(),
@@ -275,7 +277,8 @@ describe('AddUserComponent#submitForm()', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [
-        AddUserComponent
+        AddUserComponent,
+        MatSnackBarModule
       ],
       providers: [
         provideHttpClient(),


### PR DESCRIPTION
In looking at a suggestion made by Copilot, I discovered a different missing injection. This branch updates the AddUserComponent test to inject the missing MatSnackBar.